### PR TITLE
fixed. Removed letter "g"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,4 @@
-g{
+{
   "name": "turbina",
   "version": "0.1.0",
   "lockfileVersion": 1,


### PR DESCRIPTION
Убрал букву "g" из package-lock.json. При установке зависимостей выпадала ошибка, зависимости не ставились.